### PR TITLE
Update throughput.py

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -10,7 +10,16 @@ import warnings
 from typing import Any, Optional, Union
 
 import torch
-import uvloop
+import platform
+if platform.system() == "Windows":
+    import winloop as uvloop_impl
+    # Windows does not support fork
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    # Disable libuv on Windows by default
+    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")
+else:
+    import uvloop as uvloop_impl
 from tqdm import tqdm
 from transformers import (AutoModelForCausalLM, AutoTokenizer,
                           PreTrainedTokenizerBase)
@@ -537,7 +546,7 @@ def main(args: argparse.Namespace):
     request_outputs: Optional[list[RequestOutput]] = None
     if args.backend == "vllm":
         if args.async_engine:
-            elapsed_time = uvloop.run(
+            elapsed_time = uvloop_impl.run(
                 run_vllm_async(
                     requests,
                     args.n,


### PR DESCRIPTION
fix 

when run "vllm serve ..." @0.8.5
```
Lib\site-packages\vllm\benchmarks\throughput.py", line 13, in <module>
    import uvloop
ModuleNotFoundError: No module named 'uvloop'
```

