### PR TITLE
Add Windows CUDA wheel build workflow

### DIFF
--- a/.github/workflows/cuda-windows-build.yml
+++ b/.github/workflows/cuda-windows-build.yml
@@ -25,34 +25,6 @@ on:
         required: false
         default: '2.11.0.dev20260216+cu126'
         type: string
-  push:
-    branches:
-      - master
-      - 'vllm-for-windows*'
-    paths:
-      - 'CMakeLists.txt'
-      - 'setup.py'
-      - 'pyproject.toml'
-      - 'csrc/**'
-      - 'cmake/**'
-      - 'requirements/**'
-      - '.github/workflows/cuda-windows-build.yml'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'CMakeLists.txt'
-      - 'setup.py'
-      - 'pyproject.toml'
-      - 'csrc/**'
-      - 'cmake/**'
-      - 'requirements/**'
-      - '.github/workflows/cuda-windows-build.yml'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   CUDA_VERSION: ${{ inputs.cuda-version || '12.6' }}
   PYTHON_VERSION: ${{ inputs.python-version || '3.12' }}

--- a/.github/workflows/cuda-windows-build.yml
+++ b/.github/workflows/cuda-windows-build.yml
@@ -1,0 +1,216 @@
+name: Build Windows CUDA Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: 'Python version to build for'
+        required: false
+        default: '3.12'
+        type: choice
+        options:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+      cuda-version:
+        description: 'CUDA toolkit version'
+        required: false
+        default: '12.6'
+        type: choice
+        options:
+          - '12.6'
+      torch-version:
+        description: 'PyTorch version (nightly URL suffix, e.g. 2.11.0.dev20260216+cu126)'
+        required: false
+        default: '2.11.0.dev20260216+cu126'
+        type: string
+  push:
+    branches:
+      - master
+      - 'vllm-for-windows*'
+    paths:
+      - 'CMakeLists.txt'
+      - 'setup.py'
+      - 'pyproject.toml'
+      - 'csrc/**'
+      - 'cmake/**'
+      - 'requirements/**'
+      - '.github/workflows/cuda-windows-build.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'CMakeLists.txt'
+      - 'setup.py'
+      - 'pyproject.toml'
+      - 'csrc/**'
+      - 'cmake/**'
+      - 'requirements/**'
+      - '.github/workflows/cuda-windows-build.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CUDA_VERSION: ${{ inputs.cuda-version || '12.6' }}
+  PYTHON_VERSION: ${{ inputs.python-version || '3.12' }}
+  TORCH_VERSION: ${{ inputs.torch-version || '2.11.0.dev20260216+cu126' }}
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  build-cuda-windows:
+    name: Build vLLM (CUDA ${{ inputs.cuda-version || '12.6' }}, Python ${{ inputs.python-version || '3.12' }})
+    runs-on: windows-2022
+    timeout-minutes: 240
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # ----------------------------------------------------------------
+      # Install CUDA Toolkit 12.6 from NVIDIA redistributable archives
+      # This is much faster than the full installer — only the components
+      # needed for compilation are downloaded.
+      # Approach inspired by llama.cpp's CI.
+      # ----------------------------------------------------------------
+      - name: Install CUDA Toolkit ${{ env.CUDA_VERSION }}
+        env:
+          CUDA_INSTALL_DIR: "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v${{ env.CUDA_VERSION }}"
+          CUDA_REDIST_BASE: "https://developer.download.nvidia.com/compute/cuda/redist"
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # Component versions from the CUDA 12.6.2 redistrib manifest
+          $components = @(
+            "cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-12.6.77-archive.zip",
+            "cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-12.6.77-archive.zip",
+            "cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-12.6.77-archive.zip",
+            "cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-12.6.77-archive.zip",
+            "cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-12.6.77-archive.zip",
+            "cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-12.6.77-archive.zip",
+            "libcublas/windows-x86_64/libcublas-windows-x86_64-12.6.3.3-archive.zip",
+            "libcusparse/windows-x86_64/libcusparse-windows-x86_64-12.5.4.2-archive.zip",
+            "libcusolver/windows-x86_64/libcusolver-windows-x86_64-11.7.1.2-archive.zip",
+            "visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-12.6.77-archive.zip"
+          )
+
+          New-Item -ItemType Directory -Force -Path "$env:CUDA_INSTALL_DIR" | Out-Null
+          $tempDir = New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\cuda_components"
+
+          foreach ($component in $components) {
+            $url = "$env:CUDA_REDIST_BASE/$component"
+            $fileName = Split-Path $component -Leaf
+            $zipPath = Join-Path $tempDir $fileName
+            $extractDir = Join-Path $tempDir ($fileName -replace '\.zip$', '')
+
+            Write-Host "Downloading $fileName ..."
+            Invoke-WebRequest -Uri $url -OutFile $zipPath -MaximumRetryCount 3 -RetryIntervalSec 5
+
+            Write-Host "Extracting $fileName ..."
+            Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+            # The archive contains a single top-level directory; copy its contents
+            $innerDir = Get-ChildItem -Path $extractDir -Directory | Select-Object -First 1
+            Copy-Item -Path "$($innerDir.FullName)\*" -Destination "$env:CUDA_INSTALL_DIR" -Recurse -Force
+
+            Remove-Item -Path $zipPath -Force
+            Remove-Item -Path $extractDir -Recurse -Force
+          }
+
+          Write-Host "CUDA Toolkit installed to $env:CUDA_INSTALL_DIR"
+
+          # Set environment variables for subsequent steps
+          echo "CUDA_HOME=$env:CUDA_INSTALL_DIR" >> $env:GITHUB_ENV
+          echo "CUDA_PATH=$env:CUDA_INSTALL_DIR" >> $env:GITHUB_ENV
+          echo "CUDA_PATH_V12_6=$env:CUDA_INSTALL_DIR" >> $env:GITHUB_ENV
+          echo "$env:CUDA_INSTALL_DIR\bin" >> $env:GITHUB_PATH
+
+      - name: Verify CUDA installation
+        run: |
+          nvcc --version
+          Write-Host "CUDA_HOME = $env:CUDA_HOME"
+
+      # ----------------------------------------------------------------
+      # Set up Python
+      # ----------------------------------------------------------------
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # ----------------------------------------------------------------
+      # Set up build tools
+      # ----------------------------------------------------------------
+      - name: Install Ninja
+        run: |
+          choco install ninja -y
+          ninja --version
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+        with:
+          version: "v0.10.0"
+
+      # ----------------------------------------------------------------
+      # Install PyTorch (nightly with CUDA 12.6)
+      # ----------------------------------------------------------------
+      - name: Install PyTorch ${{ env.TORCH_VERSION }}
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install torch==${{ env.TORCH_VERSION }} --index-url https://download.pytorch.org/whl/nightly/cu126
+          python -c "import torch; print(f'PyTorch {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}'); print(f'CUDA version: {torch.version.cuda}')"
+
+      # ----------------------------------------------------------------
+      # Install build dependencies
+      # ----------------------------------------------------------------
+      - name: Install build dependencies
+        run: |
+          # Strip torch version pins so we use the already-installed nightly
+          python use_existing_torch.py --prefix
+
+          python -m pip install -r requirements/build.txt
+          python -m pip install -r requirements/cuda.txt
+          python -m pip install -r requirements/windows.txt
+
+      # ----------------------------------------------------------------
+      # Patch CUTLASS for MSVC compatibility
+      # ----------------------------------------------------------------
+      - name: Patch CUTLASS for MSVC
+        run: |
+          python fix_cutlass_msvc.py .
+
+      # ----------------------------------------------------------------
+      # Build vLLM wheel
+      # ----------------------------------------------------------------
+      - name: Configure and build vLLM
+        env:
+          VLLM_TARGET_DEVICE: "cuda"
+          MAX_JOBS: "2"
+          CMAKE_BUILD_TYPE: "Release"
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          # Load MSVC environment
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          Import-Module "$vsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64'
+
+          # Build the wheel
+          python setup.py bdist_wheel --dist-dir=dist
+
+      # ----------------------------------------------------------------
+      # Upload artifact
+      # ----------------------------------------------------------------
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vllm-cuda${{ env.CUDA_VERSION }}-py${{ env.PYTHON_VERSION }}-win-amd64
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Purpose

This PR adds a GitHub Actions workflow to build vLLM wheels for Windows with CUDA support. The workflow enables automated building of Windows CUDA wheels with configurable Python and CUDA versions.

The workflow:
- Downloads and installs CUDA Toolkit 12.6 components from NVIDIA redistributable archives (faster than full installer)
- Sets up Python, Ninja, and sccache for compilation
- Installs PyTorch nightly with CUDA support
- Patches CUTLASS for MSVC compatibility
- Builds the vLLM wheel using MSVC toolchain
- Uploads the resulting wheel as a GitHub artifact

The workflow is triggered manually via `workflow_dispatch` with configurable inputs for:
- Python version (3.10, 3.11, 3.12, 3.13)
- CUDA version (currently 12.6)
- PyTorch version (nightly builds)

## Test Plan

The workflow will be tested by:
1. Triggering the workflow manually from the GitHub Actions UI
2. Verifying CUDA installation completes successfully
3. Confirming the wheel builds without errors
4. Checking that the artifact is uploaded correctly

## Test Result

N/A - This is a new workflow file that will be tested upon first execution.

---

- [x] The purpose of the PR, such as "Add Windows CUDA wheel build workflow for automated wheel generation"
- [x] The test plan, such as manual workflow trigger and artifact verification
- [x] The test results will be available after first workflow execution

https://claude.ai/code/session_018SKoS4BZ8GpYa3LQMgUVQp