### PR TITLE
[Windows ARM64] Native CUDA serving enablement stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,12 +825,17 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   else()
     cuda_archs_loose_intersection(SCALED_MM_ARCHS "12.0a;12.1a" "${CUDA_ARCHS}")
   endif()
-  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8 AND SCALED_MM_ARCHS)
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8
+     AND SCALED_MM_ARCHS)
     set(SCALED_MM_SM120_SRCS
       "csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_c3x_sm120.cu"
       "csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm120_fp8.cu"
-      "csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8.cu"
     )
+    if(NOT (WIN32 AND
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$"))
+      list(APPEND SCALED_MM_SM120_SRCS
+        "csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8.cu")
+    endif()
     set_gencode_flags_for_srcs(
       SRCS "${SCALED_MM_SM120_SRCS}"
       CUDA_ARCHS "${SCALED_MM_ARCHS}")
@@ -999,20 +1004,25 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   else()
     cuda_archs_loose_intersection(FP4_SM120_ARCHS "12.0a;12.1a" "${CUDA_ARCHS}")
   endif()
-  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8 AND FP4_SM120_ARCHS)
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8
+     AND FP4_SM120_ARCHS)
     set(FP4_SM120_SRCS
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
-      "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
       "csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu")
+    if(NOT (WIN32 AND
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$"))
+      list(APPEND FP4_SM120_SRCS
+        "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu")
+      list(APPEND VLLM_GPU_FLAGS "-DENABLE_CUTLASS_MOE_SM120=1")
+    endif()
     set_gencode_flags_for_srcs(
       SRCS "${FP4_SM120_SRCS}"
       CUDA_ARCHS "${FP4_SM120_ARCHS}")
     list(APPEND VLLM_STABLE_EXT_SRC "${FP4_SM120_SRCS}")
     list(APPEND VLLM_GPU_FLAGS "-DENABLE_NVFP4_SM120=1")
-    list(APPEND VLLM_GPU_FLAGS "-DENABLE_CUTLASS_MOE_SM120=1")
     message(STATUS "Building SM12x NVFP4 for archs: ${FP4_SM120_ARCHS}")
   else()
     message(STATUS "Not building SM12x NVFP4 as no compatible archs were found.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ endif()
 
 # CUDA by default, can be overridden by using -DVLLM_TARGET_DEVICE=... (used by setup.py)
 set(VLLM_TARGET_DEVICE "cuda" CACHE STRING "Target device backend for vLLM")
+option(VLLM_BUILD_DEEPGEMM "Build and package DeepGEMM" ON)
+option(VLLM_BUILD_QUTLASS "Build and package QUTLASS" ON)
+option(VLLM_BUILD_FLASHMLA "Build and package FlashMLA" ON)
+option(VLLM_BUILD_FMHA_SM100 "Package FMHA SM100 sources" ON)
+option(VLLM_BUILD_TML_FA4 "Package TileLang FA4 sources" ON)
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Target device: ${VLLM_TARGET_DEVICE}")
 
@@ -1120,6 +1125,18 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
 
   message(STATUS "Enabling C_stable extension.")
   list(REMOVE_DUPLICATES VLLM_STABLE_EXT_SRC)
+  if(VLLM_GPU_LANG STREQUAL "CUDA" AND WIN32
+     AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+    file(TO_CMAKE_PATH "$ENV{CUDA_PATH}/lib/arm64" VLLM_CUDA_LIBRARY_DIR)
+    set(_CUBLAS_LIBRARY "${VLLM_CUDA_LIBRARY_DIR}/cublas.lib")
+    set(CUDA_cublas_LIBRARY "${_CUBLAS_LIBRARY}" CACHE FILEPATH "" FORCE)
+    foreach(CUDA_TARGET_LIBRARY cublas cublasLt)
+      if(TARGET CUDA::${CUDA_TARGET_LIBRARY})
+        set_target_properties(CUDA::${CUDA_TARGET_LIBRARY} PROPERTIES
+          IMPORTED_LOCATION "${VLLM_CUDA_LIBRARY_DIR}/${CUDA_TARGET_LIBRARY}.lib")
+      endif()
+    endforeach()
+  endif()
   if (DEFINED _CUBLAS_LIBRARY)
     define_extension_target(
       _C_stable_libtorch
@@ -1454,11 +1471,21 @@ endif()
 
 # For CUDA we also build and ship some external projects.
 if (VLLM_GPU_LANG STREQUAL "CUDA")
+  if(VLLM_BUILD_DEEPGEMM)
     include(cmake/external_projects/deepgemm.cmake)
+  endif()
+  if(VLLM_BUILD_FMHA_SM100)
     include(cmake/external_projects/fmha_sm100.cmake)
+  endif()
+  if(VLLM_BUILD_FLASHMLA)
     include(cmake/external_projects/flashmla.cmake)
+  endif()
+  if(VLLM_BUILD_QUTLASS)
     include(cmake/external_projects/qutlass.cmake)
+  endif()
+  if(VLLM_BUILD_TML_FA4)
     include(cmake/external_projects/tml_fa4.cmake)
+  endif()
 
     # vllm-flash-attn should be last as it overwrites some CMake functions
     include(cmake/external_projects/vllm_flash_attn.cmake)

--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -1,22 +1,23 @@
 # Install OpenAI triton_kernels from https://github.com/triton-lang/triton/tree/main/python/triton_kernels
 
 if(WIN32)
-  set(DEFAULT_TRITON_KERNELS_TAG "v3.6.0-windows.post26")
+  set(DEFAULT_TRITON_KERNELS_TAG "461876e8ba4446dcafbe5f99192f4b667beee308")
 else()
   set(DEFAULT_TRITON_KERNELS_TAG "v3.5.1")
 endif()
 # Set TRITON_KERNELS_SRC_DIR for use with local development with vLLM. We expect TRITON_KERNELS_SRC_DIR to
 # be directly set to the triton_kernels python directory.
 if (DEFINED ENV{TRITON_KERNELS_SRC_DIR})
-  message(STATUS "[triton_kernels] Fetch from $ENV{TRITON_KERNELS_SRC_DIR}")
+  file(TO_CMAKE_PATH "$ENV{TRITON_KERNELS_SRC_DIR}" TRITON_KERNELS_LOCAL_SOURCE_DIR)
+  message(STATUS "[triton_kernels] Fetch from ${TRITON_KERNELS_LOCAL_SOURCE_DIR}")
   FetchContent_Declare(
           triton_kernels
-          SOURCE_DIR $ENV{TRITON_KERNELS_SRC_DIR}
+    SOURCE_DIR ${TRITON_KERNELS_LOCAL_SOURCE_DIR}
   )
 
 else()
   if(WIN32)
-    set(TRITON_GIT "https://github.com/triton-lang/triton-windows.git")
+    set(TRITON_GIT "https://github.com/chinazhangchao/triton-windows.git")
   else()
     set(TRITON_GIT "https://github.com/triton-lang/triton.git")
   endif()

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -41,6 +41,7 @@ else()
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
           GIT_TAG ed4b7342bc8f0489dd9b649d5288867e35fc6a32
           GIT_PROGRESS TRUE
+          GIT_SUBMODULES csrc/cutlass
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn
   )
@@ -67,6 +68,15 @@ endif()
 
 FetchContent_MakeAvailable(vllm-flash-attn)
 message(STATUS "vllm-flash-attn is available at ${vllm-flash-attn_SOURCE_DIR}")
+
+# FA2 normally ships Ampere SASS plus forward-compatible PTX. CUDA 13 PTX can
+# be newer than the installed Windows ARM64 driver, so build native Blackwell
+# SASS and avoid a driver-side PTX JIT at runtime.
+if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+  set_target_properties(_vllm_fa2_C PROPERTIES
+    CUDA_ARCHITECTURES "120-real"
+  )
+endif()
 
 # After MakeAvailable, also force the flag onto the actual targets in case
 # the subproject's CMakeLists.txt overrides CMAKE_CUDA_FLAGS with its own

--- a/csrc/libtorch_stable/core/math.hpp
+++ b/csrc/libtorch_stable/core/math.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
+#include <bit>
 #include <climits>
 #include <iostream>
 
 inline constexpr uint32_t next_pow_2(uint32_t const num) {
   if (num <= 1) return num;
-#ifdef _WIN32
-  return 1 << (CHAR_BIT * sizeof(num) - __lzcnt(num - 1));
-#else
-  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
-#endif
+  return std::bit_ceil(num);
 }
 
 template <typename A, typename B>

--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu
@@ -124,6 +124,21 @@ struct Fp4GemmSm120 {
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+template <typename GemmKernel>
+__global__ __launch_bounds__(
+    GemmKernel::MaxThreadsPerBlock,
+    GemmKernel::
+        MinBlocksPerMultiprocessor) void cutlass_kernel_indirect(typename GemmKernel::
+                                                                     Params const*
+                                                                         params) {
+  extern __shared__ char smem[];
+  GemmKernel op;
+  op(*params, smem);
+  cutlass::arch::synclog_print();
+}
+#endif
+
 template <typename Gemm>
 typename Gemm::Arguments args_from_options(torch::stable::Tensor& D,
                                            torch::stable::Tensor const& A,
@@ -180,20 +195,65 @@ void runGemm(torch::stable::Tensor& D, torch::stable::Tensor const& A,
              torch::stable::Tensor const& B_sf,
              torch::stable::Tensor const& alpha, int M, int N, int K,
              cudaStream_t stream) {
-  Gemm gemm;
-
   auto arguments = args_from_options<Gemm>(D, A, B, A_sf, B_sf, alpha, M, N, K);
 
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+  using GemmKernel = typename Gemm::GemmKernel;
+  using Params = typename GemmKernel::Params;
+  constexpr size_t params_alignment = alignof(Params);
+  constexpr size_t params_storage_size =
+      (sizeof(Params) + params_alignment - 1) / params_alignment *
+      params_alignment;
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  auto workspace = torch::stable::empty(params_storage_size + workspace_size,
+                                        torch::headeronly::ScalarType::Byte,
+                                        std::nullopt, A.device());
+  auto* params_device = static_cast<uint8_t*>(workspace.data_ptr());
+  STD_TORCH_CHECK(
+      reinterpret_cast<uintptr_t>(params_device) % params_alignment == 0,
+      "CUTLASS workspace does not satisfy Params alignment");
+  void* gemm_workspace = params_device + params_storage_size;
+
+  CUTLASS_CHECK(Gemm::can_implement(arguments));
+  CUTLASS_CHECK(
+      GemmKernel::initialize_workspace(arguments, gemm_workspace, stream));
+
+  Params params =
+      GemmKernel::to_underlying_arguments(arguments, gemm_workspace);
+  auto cuda_status = cudaMemcpyAsync(params_device, &params, sizeof(Params),
+                                     cudaMemcpyHostToDevice, stream);
+  STD_TORCH_CHECK(cuda_status == cudaSuccess, "Failed to copy CUTLASS Params: ",
+                  cudaGetErrorString(cuda_status));
+
+  constexpr int smem_size = GemmKernel::SharedStorageSize;
+  if constexpr (smem_size >= (48 << 10)) {
+    cuda_status = cudaFuncSetAttribute(
+        cutlass_kernel_indirect<GemmKernel>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    STD_TORCH_CHECK(cuda_status == cudaSuccess,
+                    "Failed to configure CUTLASS dynamic shared memory: ",
+                    cudaGetErrorString(cuda_status));
+  }
+
+  auto grid = GemmKernel::get_grid_shape(params);
+  auto block = GemmKernel::get_block_shape();
+  cutlass_kernel_indirect<GemmKernel><<<grid, block, smem_size, stream>>>(
+      reinterpret_cast<Params const*>(params_device));
+  cuda_status = cudaGetLastError();
+  STD_TORCH_CHECK(cuda_status == cudaSuccess,
+                  "Failed to launch CUTLASS NVFP4 kernel: ",
+                  cudaGetErrorString(cuda_status));
+#else
+  Gemm gemm;
   size_t workspace_size = Gemm::get_workspace_size(arguments);
   auto workspace =
       torch::stable::empty(workspace_size, torch::headeronly::ScalarType::Byte,
                            std::nullopt, A.device());
 
   CUTLASS_CHECK(gemm.can_implement(arguments));
-
   CUTLASS_CHECK(gemm.initialize(arguments, workspace.data_ptr(), stream));
-
   CUTLASS_CHECK(gemm.run(arguments, workspace.data_ptr(), stream));
+#endif
 }
 
 namespace {

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/cutlass_gemm_caller.cuh
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/cutlass_gemm_caller.cuh
@@ -25,6 +25,21 @@
 
 namespace vllm::c3x {
 
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+template <typename GemmKernel>
+__global__ __launch_bounds__(
+    GemmKernel::MaxThreadsPerBlock,
+    GemmKernel::
+        MinBlocksPerMultiprocessor) void cutlass_kernel_indirect(typename GemmKernel::
+                                                                     Params const*
+                                                                         params) {
+  extern __shared__ char smem[];
+  GemmKernel op;
+  op(*params, smem);
+  cutlass::arch::synclog_print();
+}
+#endif
+
 static inline cute::Shape<int, int, int, int> get_problem_shape(
     torch::stable::Tensor const& a, torch::stable::Tensor const& b) {
   int32_t m = a.size(0), n = b.size(1), k = a.size(1);
@@ -48,18 +63,61 @@ void cutlass_gemm_caller(
 
   // Launch the CUTLASS GEMM kernel.
   using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-  GemmOp gemm_op;
-  CUTLASS_CHECK(gemm_op.can_implement(args));
+  CUTLASS_CHECK(GemmOp::can_implement(args));
 
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+  using Params = typename GemmKernel::Params;
+  constexpr size_t params_alignment = alignof(Params);
+  constexpr size_t params_storage_size =
+      (sizeof(Params) + params_alignment - 1) / params_alignment *
+      params_alignment;
+  size_t workspace_size = GemmOp::get_workspace_size(args);
+  auto workspace = torch::stable::empty(params_storage_size + workspace_size,
+                                        torch::headeronly::ScalarType::Byte,
+                                        std::nullopt, device);
+  auto* params_device = static_cast<uint8_t*>(workspace.data_ptr());
+  STD_TORCH_CHECK(
+      reinterpret_cast<uintptr_t>(params_device) % params_alignment == 0,
+      "CUTLASS workspace does not satisfy Params alignment");
+  void* gemm_workspace = params_device + params_storage_size;
+
+  auto stream = get_current_cuda_stream(device.index());
+  CUTLASS_CHECK(GemmKernel::initialize_workspace(args, gemm_workspace, stream));
+  Params params = GemmKernel::to_underlying_arguments(args, gemm_workspace);
+
+  auto cuda_status = cudaMemcpyAsync(params_device, &params, sizeof(Params),
+                                     cudaMemcpyHostToDevice, stream);
+  STD_TORCH_CHECK(cuda_status == cudaSuccess, "Failed to copy CUTLASS Params: ",
+                  cudaGetErrorString(cuda_status));
+
+  constexpr int smem_size = GemmKernel::SharedStorageSize;
+  if constexpr (smem_size >= (48 << 10)) {
+    cuda_status = cudaFuncSetAttribute(
+        cutlass_kernel_indirect<GemmKernel>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    STD_TORCH_CHECK(cuda_status == cudaSuccess,
+                    "Failed to configure CUTLASS dynamic shared memory: ",
+                    cudaGetErrorString(cuda_status));
+  }
+
+  auto grid = GemmKernel::get_grid_shape(params);
+  auto block = GemmKernel::get_block_shape();
+  cutlass_kernel_indirect<GemmKernel><<<grid, block, smem_size, stream>>>(
+      reinterpret_cast<Params const*>(params_device));
+  cuda_status = cudaGetLastError();
+  STD_TORCH_CHECK(cuda_status == cudaSuccess,
+                  "Failed to launch CUTLASS scaled GEMM: ",
+                  cudaGetErrorString(cuda_status));
+#else
+  GemmOp gemm_op;
   size_t workspace_size = gemm_op.get_workspace_size(args);
   auto workspace =
       torch::stable::empty(workspace_size, torch::headeronly::ScalarType::Byte,
                            std::nullopt, device);
 
-  auto stream = get_current_cuda_stream(device.index());
-
   cutlass::Status status = gemm_op.run(args, workspace.data_ptr(), stream);
   CUTLASS_CHECK(status);
+#endif
 }
 
 template <typename Gemm, typename... EpilogueArgs>

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_helper.hpp
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_helper.hpp
@@ -52,6 +52,11 @@ void dispatch_scaled_mm(torch::stable::Tensor& c,
     }
 
     STD_TORCH_CHECK(!bias, "Bias not yet supported blockwise scaled_mm");
-    blockwise_func(c, a, b, a_scales, b_scales);
+    if constexpr (!std::is_same_v<BlockwiseFunc, std::nullptr_t>) {
+      blockwise_func(c, a, b, a_scales, b_scales);
+    } else {
+      STD_TORCH_CHECK(false,
+                      "Blockwise FP8 is not supported by this CUTLASS build.");
+    }
   }
 }

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_c3x_sm120.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_c3x_sm120.cu
@@ -14,10 +14,17 @@ void cutlass_scaled_mm_sm120(torch::stable::Tensor& c,
                              torch::stable::Tensor const& a_scales,
                              torch::stable::Tensor const& b_scales,
                              std::optional<torch::stable::Tensor> const& bias) {
+  #if defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+  dispatch_scaled_mm(c, a, b, a_scales, b_scales, bias,
+                     vllm::cutlass_scaled_mm_sm120_fp8,
+                     nullptr,   // int8 not supported on SM120
+                     nullptr);  // blockwise FP8 is not built on Windows ARM64
+  #else
   dispatch_scaled_mm(c, a, b, a_scales, b_scales, bias,
                      vllm::cutlass_scaled_mm_sm120_fp8,
                      nullptr,  // int8 not supported on SM120
                      vllm::cutlass_scaled_mm_blockwise_sm120_fp8);
+  #endif
 }
 
 #endif

--- a/csrc/spinloop.cpp
+++ b/csrc/spinloop.cpp
@@ -178,8 +178,10 @@ static PyObject* method_spinloop(PyObject* self, PyObject* args,
       Py_BEGIN_ALLOW_THREADS
 #if defined(__i386__) || defined(__x86_64__)
       __builtin_ia32_pause();
+#elif defined(_M_ARM64)
+  YieldProcessor();
 #elif defined(__aarch64__)
-        __asm__ volatile("yield" :: : "memory");
+  __asm__ volatile("yield" :: : "memory");
 #endif
       Py_END_ALLOW_THREADS
 #if defined(__i386__) || defined(__x86_64__)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,10 +21,10 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
-llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
+llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "ARM64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
 outlines_core == 0.2.14
 lark == 1.2.2
-xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "ARM64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -6,30 +6,30 @@ numba == 0.65.0 # Required for N-gram speculative decoding
 # Dependencies for NVIDIA GPUs
 torch==2.11.0; sys_platform != "win32"
 torchaudio==2.11.0; sys_platform != "win32"
-torch==2.11.0+cu130; sys_platform == "win32"
-torchaudio==2.11.0+cu130; sys_platform == "win32"
+torch==2.11.0+cu130; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
+torchaudio==2.11.0+cu130; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
 # These must be updated alongside torch
 torchvision==0.26.0; sys_platform != "win32" # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-torchvision==0.26.0+cu130; sys_platform == "win32" # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-torchcodec >= 0.14
-PyNvVideoCodec==2.0.4
+torchvision==0.26.0+cu130; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64" # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+torchcodec >= 0.14; platform_system != "Windows" or (platform_machine != "ARM64" and platform_machine != "arm64")
+PyNvVideoCodec==2.0.4; platform_system != "Windows" or (platform_machine != "ARM64" and platform_machine != "arm64")
 # FlashInfer should be updated together with the Dockerfile
 # flashinfer-cubin is not on PyPI since 0.6.14; setup.py excludes it from
 # install_requires so the published wheel does not carry an unresolvable pin
 --extra-index-url https://flashinfer.ai/whl/
 flashinfer-python==0.6.15.post1; sys_platform != "win32"
 flashinfer-cubin==0.6.15.post1; sys_platform != "win32"
-flashinfer-python @ https://github.com/SystemPanic/flashinfer-windows/releases/download/v0.6.11.post3/flashinfer_python-0.6.11.post3-py3-none-any.whl ; sys_platform == "win32"
-flashinfer-cubin==0.6.11.post3; sys_platform == "win32"
-apache-tvm-ffi==0.1.10
+flashinfer-python @ https://github.com/SystemPanic/flashinfer-windows/releases/download/v0.6.11.post3/flashinfer_python-0.6.11.post3-py3-none-any.whl ; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
+flashinfer-cubin==0.6.11.post3; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
+apache-tvm-ffi==0.1.10; platform_system != "Windows" or (platform_machine != "ARM64" and platform_machine != "arm64")
 tilelang==0.1.9; sys_platform != "win32"
-tilelang==0.1.10; sys_platform == "win32"
+tilelang==0.1.10; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
 nvidia-cudnn-frontend>=1.19.1; sys_platform != "win32"
-nvidia-cudnn-frontend>=1.13.0,<1.19.0; sys_platform == "win32"
+nvidia-cudnn-frontend>=1.13.0,<1.19.0; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"
 # Required for LLM_NVTX_SCOPES_FOR_PROFILING=1
 nvtx==0.2.15
 # Required for faster safetensors model loading
-fastsafetensors >= 0.3.2
+fastsafetensors >= 0.3.2; platform_system != "Windows" or (platform_machine != "ARM64" and platform_machine != "arm64")
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl[cu13]==4.6.0; sys_platform != "win32"
@@ -40,4 +40,4 @@ tokenspeed-mla==0.1.8; platform_system == "Linux"
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.10; sys_platform != "win32"
-humming-kernels[cu13] @ git+https://github.com/SystemPanic/humming-windows.git@v0.1.10 ; sys_platform == "win32"
+humming-kernels[cu13] @ git+https://github.com/SystemPanic/humming-windows.git@v0.1.10 ; sys_platform == "win32" and platform_machine != "ARM64" and platform_machine != "arm64"

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,4 +1,4 @@
 winloop
-triton-windows==3.6.0.post26
-xformers==0.0.35
+triton-windows==3.8.0
+xformers==0.0.35; platform_machine != "ARM64" and platform_machine != "arm64"
 portalocker

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5566,6 +5566,7 @@ dependencies = [
  "itertools 0.14.0",
  "mimalloc",
  "native-tls",
+ "openssl",
  "serde",
  "serde_json",
  "serde_with",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,6 +63,7 @@ mimalloc = "0.1.52"
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 native-tls-vendored = { package = "native-tls", version = "0.2.18", features = ["vendored"] }
+openssl-vendored = { package = "openssl", version = "0.10.81", features = ["vendored"] }
 ndarray = { version = "0.17", features = ["serde"] }
 openai-harmony = { package = "oss-harmony", git = "https://github.com/oss-harmony/harmony", tag = "v0.0.11", default-features = false }
 openai-protocol = "1.6.0"

--- a/rust/src/cmd/Cargo.toml
+++ b/rust/src/cmd/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [features]
 default = []
-native-tls-vendored = ["dep:native-tls-vendored"]
+native-tls-vendored = ["dep:native-tls-vendored", "dep:openssl-vendored"]
 
 [dependencies]
 anyhow.workspace = true
@@ -19,6 +19,7 @@ educe.workspace = true
 itertools.workspace = true
 mimalloc.workspace = true
 native-tls-vendored = { workspace = true, optional = true }
+openssl-vendored = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true

--- a/rust/src/cmd/src/main.rs
+++ b/rust/src/cmd/src/main.rs
@@ -64,16 +64,24 @@ fn shutdown_signal() -> CancellationToken {
             tokio::signal::ctrl_c().await.expect("failed to install Ctrl-C signal handler");
         };
 
-        let sigterm = async {
+        #[cfg(unix)]
+        let terminate = async {
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                 .expect("failed to install SIGTERM signal handler")
+                .recv()
+                .await;
+        };
+        #[cfg(windows)]
+        let terminate = async {
+            tokio::signal::windows::ctrl_break()
+                .expect("failed to install Ctrl-Break signal handler")
                 .recv()
                 .await;
         };
 
         tokio::select! {
             _ = ctrl_c => info!("received shutdown signal (Ctrl-C), shutting down..."),
-            _ = sigterm => info!("received shutdown signal (SIGTERM), shutting down..."),
+            _ = terminate => info!("received termination signal, shutting down..."),
         }
 
         shutdown.cancel();

--- a/rust/src/engine-core-client/src/mock_engine.rs
+++ b/rust/src/engine-core-client/src/mock_engine.rs
@@ -130,16 +130,24 @@ fn peer_identity(engine_id: impl Into<EngineId>) -> Result<PeerIdentity> {
 /// Wait for an endpoint to accept connections before attempting the ZMQ connect.
 async fn wait_for_endpoint(endpoint: &str, connect_timeout: Duration) -> Result<()> {
     if let Some(socket_path) = endpoint.strip_prefix("ipc://") {
-        timeout(connect_timeout, async {
-            while tokio::net::UnixStream::connect(socket_path).await.is_err() {
-                sleep(Duration::from_millis(20)).await;
-            }
-        })
-        .await
-        .map_err(|_| Error::HandshakeTimeout {
-            stage: "mock engine IPC endpoint",
-            timeout: connect_timeout,
-        })
+        #[cfg(unix)]
+        {
+            timeout(connect_timeout, async {
+                while tokio::net::UnixStream::connect(socket_path).await.is_err() {
+                    sleep(Duration::from_millis(20)).await;
+                }
+            })
+            .await
+            .map_err(|_| Error::HandshakeTimeout {
+                stage: "mock engine IPC endpoint",
+                timeout: connect_timeout,
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (socket_path, connect_timeout);
+            Ok(())
+        }
     } else if let Some(address) = endpoint.strip_prefix("tcp://") {
         timeout(connect_timeout, async {
             while tokio::net::TcpStream::connect(address).await.is_err() {

--- a/rust/src/managed-engine/src/process.rs
+++ b/rust/src/managed-engine/src/process.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+#[cfg(unix)]
 use std::io;
 use std::net::TcpListener;
 use std::process::{Command as StdCommand, ExitStatus, Stdio};
@@ -140,7 +141,7 @@ impl ManagedEngineHandle {
         info!(
             pid,
             ?shutdown_timeout,
-            "shutting down managed engine with SIGTERM"
+            "shutting down managed engine process group"
         );
         process_group::terminate(pid)?;
 
@@ -152,7 +153,7 @@ impl ManagedEngineHandle {
         // If it doesn't exit within the timeout, force kill it.
         info!(
             pid,
-            "managed engine did not exit within timeout, sending SIGKILL"
+            "managed engine did not exit within timeout, forcing termination"
         );
         process_group::kill(pid)?;
 
@@ -163,6 +164,7 @@ impl ManagedEngineHandle {
 
 /// Process group helper functions for managing the Python subprocess and its
 /// potential children in a platform-aware way.
+#[cfg(unix)]
 mod process_group {
     use super::*;
 
@@ -201,6 +203,45 @@ mod process_group {
             return Ok(());
         }
         Err(error).context("failed to signal managed engine process group")
+    }
+}
+
+#[cfg(windows)]
+mod process_group {
+    use super::*;
+
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+    pub fn configure(command: &mut Command) {
+        command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    }
+
+    pub fn terminate(pid: u32) -> Result<()> {
+        taskkill(pid, false)
+    }
+
+    pub fn kill(pid: u32) -> Result<()> {
+        taskkill(pid, true)
+    }
+
+    fn taskkill(pid: u32, force: bool) -> Result<()> {
+        let mut command = StdCommand::new("taskkill.exe");
+        command.arg("/PID").arg(pid.to_string()).arg("/T");
+        if force {
+            command.arg("/F");
+        }
+
+        let output = command
+            .output()
+            .context("failed to run taskkill for managed engine process group")?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        Err(anyhow::anyhow!(
+            "taskkill failed for managed engine process group {pid}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
     }
 }
 

--- a/rust/src/server/src/listener.rs
+++ b/rust/src/server/src/listener.rs
@@ -8,17 +8,24 @@
 //! `axum::serve(...)` through a single type.
 
 use std::io::Result;
-use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::net::SocketAddr;
+#[cfg(unix)]
+use std::net::TcpListener as StdTcpListener;
+#[cfg(unix)]
 use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+#[cfg(unix)]
 use std::os::unix::net::UnixListener as StdUnixListener;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use auto_enums::enum_derive;
 use openssl::ssl::SslContext;
+#[cfg(unix)]
 use socket2::Socket;
 use tls_listener::{AsyncAccept, AsyncListener};
-use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+use tokio::net::{TcpListener, TcpStream};
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
 use tonic::transport::server::{Connected, TcpConnectInfo};
 use tracing::trace;
 
@@ -29,10 +36,12 @@ use crate::{HttpListenerMode, tls};
 #[derive(Debug)]
 pub enum Listener {
     Tcp(TcpListener),
+    #[cfg(unix)]
     Unix(UnixListener),
 }
 
 /// Runtime listener I/O type which is either a TCP stream or a Unix-domain stream.
+#[cfg(unix)]
 #[derive(Debug)]
 #[enum_derive(tokio1::AsyncRead, tokio1::AsyncWrite)]
 pub enum ListenerIo {
@@ -40,11 +49,19 @@ pub enum ListenerIo {
     Unix(UnixStream),
 }
 
+#[cfg(not(unix))]
+#[derive(Debug)]
+#[enum_derive(tokio1::AsyncRead, tokio1::AsyncWrite)]
+pub enum ListenerIo {
+    Tcp(TcpStream),
+}
+
 /// Runtime listener address type which is either a TCP address or a Unix-domain address.
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum ListenerAddr {
     Tcp(SocketAddr),
+    #[cfg(unix)]
     Unix(tokio::net::unix::SocketAddr),
 }
 
@@ -58,8 +75,34 @@ impl Listener {
             HttpListenerMode::BindTcp { host, port } => {
                 Ok(Self::Tcp(TcpListener::bind((host.as_str(), *port)).await?))
             }
-            HttpListenerMode::BindUnix { path } => Ok(Self::Unix(UnixListener::bind(path)?)),
-            HttpListenerMode::InheritedFd { fd } => Self::from_inherited_fd(*fd),
+            HttpListenerMode::BindUnix { path } => {
+                #[cfg(unix)]
+                {
+                    Ok(Self::Unix(UnixListener::bind(path)?))
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = path;
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "Unix listeners are not supported on this platform",
+                    ))
+                }
+            }
+            HttpListenerMode::InheritedFd { fd } => {
+                #[cfg(unix)]
+                {
+                    Self::from_inherited_fd(*fd)
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = fd;
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "inherited file-descriptor listeners are not supported on this platform",
+                    ))
+                }
+            }
         }
     }
 
@@ -68,6 +111,7 @@ impl Listener {
     pub fn local_addr_display(&self) -> Result<String> {
         match self {
             Self::Tcp(listener) => Ok(listener.local_addr()?.to_string()),
+            #[cfg(unix)]
             Self::Unix(listener) => Ok(match listener.local_addr()?.as_pathname() {
                 Some(path) => format!("unix:{}", path.display()),
                 None => "unix:<unnamed>".to_string(),
@@ -75,6 +119,7 @@ impl Listener {
         }
     }
 
+    #[cfg(unix)]
     fn from_inherited_fd(fd: i32) -> Result<Self> {
         // SAFETY: We trust the caller to only pass valid listener fds, and we only use
         // this fd once to create a single listener.
@@ -99,6 +144,7 @@ impl Listener {
     fn local_addr(&self) -> Result<ListenerAddr> {
         match self {
             Self::Tcp(listener) => listener.local_addr().map(ListenerAddr::Tcp),
+            #[cfg(unix)]
             Self::Unix(listener) => listener.local_addr().map(ListenerAddr::Unix),
         }
     }
@@ -111,6 +157,7 @@ impl Connected for ListenerIo {
     fn connect_info(&self) -> TcpConnectInfo {
         match self {
             Self::Tcp(stream) => stream.connect_info(),
+            #[cfg(unix)]
             Self::Unix(_) => TcpConnectInfo {
                 local_addr: None,
                 remote_addr: None,
@@ -141,6 +188,7 @@ impl axum::serve::Listener for Listener {
                     ListenerAddr::Tcp(addr),
                 )
             }
+            #[cfg(unix)]
             Self::Unix(listener) => {
                 let (io, addr) = axum::serve::Listener::accept(listener).await;
                 (ListenerIo::Unix(io), ListenerAddr::Unix(addr))
@@ -171,6 +219,7 @@ impl AsyncAccept for Listener {
                     ListenerAddr::Tcp(addr),
                 )))
             }
+            #[cfg(unix)]
             Self::Unix(listener) => {
                 let (io, addr) = ready!(listener.poll_accept(cx))?;
                 Poll::Ready(Ok((ListenerIo::Unix(io), ListenerAddr::Unix(addr))))
@@ -273,7 +322,7 @@ impl futures::Stream for MaybeTlsListener {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
     use std::os::fd::IntoRawFd;

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,18 @@ def load_module_from_path(module_name, path):
 ROOT_DIR = Path(__file__).parent
 logger = logging.getLogger(__name__)
 
-PRECOMPILED_RUST_FRONTEND_PATH = ROOT_DIR / "vllm" / "vllm-rs"
+RUST_FRONTEND_FILENAME = (
+    "vllm-rs.exe" if sys.platform.startswith("win") else "vllm-rs"
+)
+PRECOMPILED_RUST_FRONTEND_PATH = ROOT_DIR / "vllm" / RUST_FRONTEND_FILENAME
 # setuptools-rust installs PyO3 artifacts as `<module>.<ext-suffix>`, where the
-# suffix ends with `.so` on Linux and macOS alike (e.g. `_rust_foo.abi3.so`).
-PRECOMPILED_RUST_EXTENSION_MEMBER_REGEX = re.compile(r"vllm/_rust_[^/]*\.so$")
+# suffix ends with `.so` on Linux/macOS and `.pyd` on Windows.
+PRECOMPILED_RUST_EXTENSION_MEMBER_REGEX = re.compile(
+    r"vllm/_rust_[^/]*\.(?:so|pyd)$"
+)
+PRECOMPILED_WINDOWS_EXTENSION_MEMBER_REGEX = re.compile(
+    r"vllm/(?:[^/]+/)*[^/]+\.pyd$"
+)
 
 # cannot import envs directly because it depends on vllm,
 #  which is not installed yet
@@ -61,7 +69,11 @@ def should_require_rust_frontend() -> bool:
 
 
 def get_precompiled_rust_extension_paths() -> list[Path]:
-    return sorted((ROOT_DIR / "vllm").glob("_rust_*.so"))
+    return sorted(
+        path
+        for pattern in ("_rust_*.so", "_rust_*.pyd")
+        for path in (ROOT_DIR / "vllm").glob(pattern)
+    )
 
 
 def get_missing_precompiled_rust_extension_modules() -> list[str]:
@@ -263,6 +275,15 @@ class cmake_build_ext(build_ext):
             "-DCMAKE_BUILD_TYPE={}".format(cfg),
             "-DVLLM_TARGET_DEVICE={}".format(VLLM_TARGET_DEVICE),
         ]
+        for option in (
+            "VLLM_BUILD_DEEPGEMM",
+            "VLLM_BUILD_QUTLASS",
+            "VLLM_BUILD_FLASHMLA",
+            "VLLM_BUILD_FMHA_SM100",
+            "VLLM_BUILD_TML_FA4",
+        ):
+            enabled = "ON" if getattr(envs, option) else "OFF"
+            cmake_args.append(f"-D{option}={enabled}")
 
         verbose = envs.VERBOSE
         if verbose:
@@ -300,9 +321,19 @@ class cmake_build_ext(build_ext):
 
         if VLLM_TARGET_DEVICE == 'cuda':
             if IS_WINDOWS:
+                cuda_lib_arch = (
+                    "arm64"
+                    if platform.machine().lower() in ("arm64", "aarch64")
+                    else "x64"
+                )
                 cmake_args += [
                     f'-Dnvtx3_dir={CUDA_HOME}\\include',
-                    f'-DCUDA_cublas_LIBRARY={CUDA_HOME}\\lib\\x64\\cublas.lib'
+                    f'-DCUDAToolkit_LIBRARY_DIR={CUDA_HOME}\\lib\\{cuda_lib_arch}',
+                    f'-DCUDA_cublas_LIBRARY={CUDA_HOME}\\lib\\{cuda_lib_arch}\\cublas.lib',
+                    f'-DCUDA_cuda_driver_LIBRARY={CUDA_HOME}\\lib\\{cuda_lib_arch}\\cuda.lib',
+                    f'-DCUDA_cudart_LIBRARY={CUDA_HOME}\\lib\\{cuda_lib_arch}\\cudart.lib',
+                    f'-DCUDA_CUDART_LIBRARY={CUDA_HOME}\\lib\\{cuda_lib_arch}\\cudart.lib',
+                    f'-DCUDA_nvrtc_LIBRARY={CUDA_HOME}\\lib\\{cuda_lib_arch}\\nvrtc.lib',
                 ]
 
         # Override the base directory for FetchContent downloads to $ROOT/.deps
@@ -822,7 +853,7 @@ class precompiled_wheel_utils:
                         }
                     )
                 if extract_rust_frontend:
-                    exact_members.add("vllm/vllm-rs")
+                    exact_members.add(f"vllm/{RUST_FRONTEND_FILENAME}")
 
                 flash_attn_regex = re.compile(
                     r"vllm/vllm_flash_attn/(?:[^/.][^/]*/)*(?!\.)[^/]*\.py"
@@ -846,6 +877,14 @@ class precompiled_wheel_utils:
                 file_members = []
                 for member in wheel.filelist:
                     if member.filename in exact_members:
+                        file_members.append(member)
+                        continue
+                    if (
+                        extract_extensions
+                        and PRECOMPILED_WINDOWS_EXTENSION_MEMBER_REGEX.match(
+                            member.filename
+                        )
+                    ):
                         file_members.append(member)
                         continue
                     if (
@@ -1174,9 +1213,9 @@ if _is_cuda():
     ext_modules.append(
         CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa4_cutedsl_C", optional=True)
     )
-    if USE_PRECOMPILED_EXTENSIONS or (
+    if envs.VLLM_BUILD_FLASHMLA and (USE_PRECOMPILED_EXTENSIONS or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.9")
-    ):
+    )):
         # FlashMLA requires CUDA 12.9 or later
         # Optional since this doesn't get built (produce an .so file) when
         # not targeting a hopper system
@@ -1184,17 +1223,22 @@ if _is_cuda():
         ext_modules.append(
             CMakeExtension(name="vllm._flashmla_extension_C", optional=True)
         )
-    if envs.VLLM_USE_PRECOMPILED or (
+    if envs.VLLM_BUILD_DEEPGEMM and (envs.VLLM_USE_PRECOMPILED or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
-    ):
+    )):
         # DeepGEMM requires CUDA 12.3+ (SM90/SM100)
         # Optional since it won't build on unsupported architectures
         ext_modules.append(CMakeExtension(name="vllm._deep_gemm_C", optional=True))
+    if envs.VLLM_BUILD_QUTLASS and (envs.VLLM_USE_PRECOMPILED or (
+        CUDA_HOME and get_nvcc_cuda_version() >= Version("12.8")
+    )):
         ext_modules.append(CMakeExtension(name="vllm._qutlass_C", optional=True))
     # fmha_sm100 is a Python/CuTe-DSL package installed into vllm.third_party.
-    ext_modules.append(CMakeExtension(name="vllm.fmha_sm100", optional=True))
+    if envs.VLLM_BUILD_FMHA_SM100:
+        ext_modules.append(CMakeExtension(name="vllm.fmha_sm100", optional=True))
     # tml-fa4 is copied into an isolated vllm.third_party package.
-    ext_modules.append(CMakeExtension(name="vllm.tml_fa4", optional=True))
+    if envs.VLLM_BUILD_TML_FA4:
+        ext_modules.append(CMakeExtension(name="vllm.tml_fa4", optional=True))
 
 if _is_cpu():
     import platform
@@ -1262,7 +1306,7 @@ if USE_PRECOMPILED_RUST_FRONTEND:
 # If the rust frontend binary is already present in the source tree (e.g.,
 # pre-built in a separate Docker build stage), ship it as-is.
 if PRECOMPILED_RUST_FRONTEND_PATH.exists():
-    add_vllm_package_data("vllm-rs")
+    add_vllm_package_data(RUST_FRONTEND_FILENAME)
 for rust_extension_path in get_precompiled_rust_extension_paths():
     add_vllm_package_data(rust_extension_path.name)
 

--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -8,9 +8,28 @@ import pytest
 from huggingface_hub.utils import LocalEntryNotFoundError
 
 from vllm.model_executor.model_loader.weight_utils import (
+    _synchronize_safetensors_mmap_before_close,
     download_weights_from_hf,
     maybe_remap_kv_scale_name,
 )
+
+
+def test_synchronize_safetensors_mmap_on_windows_integrated_gpu(monkeypatch):
+    from vllm.model_executor.model_loader import weight_utils
+
+    synchronize_calls = []
+    monkeypatch.setattr(weight_utils.os, "name", "nt")
+    monkeypatch.setattr(weight_utils.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        weight_utils.current_platform, "is_integrated_gpu", lambda device: True
+    )
+    monkeypatch.setattr(weight_utils.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        weight_utils.torch.cuda, "synchronize", lambda: synchronize_calls.append(0)
+    )
+
+    assert _synchronize_safetensors_mmap_before_close()
+    assert synchronize_calls == [0]
 
 
 def test_download_weights_from_hf():

--- a/tests/vllm_flash_attn/test_flash_attn_interface.py
+++ b/tests/vllm_flash_attn/test_flash_attn_interface.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def flash_attn_interface(monkeypatch: pytest.MonkeyPatch):
+    platform_module = ModuleType("vllm.platforms")
+    platform_module.current_platform = None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vllm.platforms", platform_module)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "vllm"
+        / "vllm_flash_attn"
+        / "flash_attn_interface.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "flash_attn_interface_under_test", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.FA4_AVAILABLE = True
+    return module, platform_module
+
+
+@pytest.mark.parametrize("capability", [90, 100, 110, 120])
+def test_fa4_supported_capability_families(
+    flash_attn_interface, capability, monkeypatch
+):
+    module, platform_module = flash_attn_interface
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: object())
+    platform_module.current_platform = SimpleNamespace(
+        is_device_capability_family=lambda family: family == capability
+    )
+
+    assert module._is_fa4_supported() == (True, None)
+
+
+def test_fa4_rejects_unsupported_capability_family(
+    flash_attn_interface, monkeypatch
+):
+    module, platform_module = flash_attn_interface
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: object())
+    platform_module.current_platform = SimpleNamespace(
+        is_device_capability_family=lambda family: False
+    )
+
+    supported, reason = module._is_fa4_supported()
+
+    assert not supported
+    assert "12.x" in reason
+
+
+def test_fa4_requires_cutlass_dsl_runtime(flash_attn_interface, monkeypatch):
+    module, _ = flash_attn_interface
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: None)
+
+    assert module._is_fa4_supported() == (
+        False,
+        "FA4 requires the nvidia-cutlass-dsl runtime",
+    )

--- a/vllm/entrypoints/cli/benchmark/serve.py
+++ b/vllm/entrypoints/cli/benchmark/serve.py
@@ -12,7 +12,9 @@ from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 logger = init_logger(__name__)
-_RUST_CLI_PATH = Path(__file__).resolve().parents[3] / "vllm-rs"
+_RUST_CLI_PATH = Path(__file__).resolve().parents[3] / (
+    "vllm-rs.exe" if sys.platform.startswith("win") else "vllm-rs"
+)
 _RUST_SUPPORTED_DATASETS = frozenset(
     {
         "custom",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -104,6 +104,11 @@ if TYPE_CHECKING:
     VLLM_BUILD_PIPELINE: str = "local"
     VLLM_BUILD_URL: str = ""
     VLLM_IMAGE_TAG: str = ""
+    VLLM_BUILD_DEEPGEMM: bool = True
+    VLLM_BUILD_QUTLASS: bool = True
+    VLLM_BUILD_FLASHMLA: bool = True
+    VLLM_BUILD_FMHA_SM100: bool = True
+    VLLM_BUILD_TML_FA4: bool = True
     VLLM_KEEP_ALIVE_ON_ENGINE_DEATH: bool = False
     CMAKE_BUILD_TYPE: Literal["Debug", "Release", "RelWithDebInfo"] | None = None
     VERBOSE: bool = False
@@ -572,7 +577,8 @@ def _resolve_rust_frontend_path() -> str | None:
 
     if raw.lower() in ("auto", "1", "true"):
         pkg_dir = os.path.dirname(os.path.abspath(__file__))
-        candidate = os.path.join(pkg_dir, "vllm-rs")
+        filename = "vllm-rs.exe" if sys.platform.startswith("win") else "vllm-rs"
+        candidate = os.path.join(pkg_dir, filename)
         if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
             return candidate
 
@@ -656,6 +662,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_BUILD_PIPELINE": lambda: os.environ.get("VLLM_BUILD_PIPELINE", "local"),
     "VLLM_BUILD_URL": lambda: os.environ.get("VLLM_BUILD_URL", ""),
     "VLLM_IMAGE_TAG": lambda: os.environ.get("VLLM_IMAGE_TAG", ""),
+    "VLLM_BUILD_DEEPGEMM": lambda: bool(
+        int(os.environ.get("VLLM_BUILD_DEEPGEMM", "1"))
+    ),
+    "VLLM_BUILD_QUTLASS": lambda: bool(
+        int(os.environ.get("VLLM_BUILD_QUTLASS", "1"))
+    ),
+    "VLLM_BUILD_FLASHMLA": lambda: bool(
+        int(os.environ.get("VLLM_BUILD_FLASHMLA", "1"))
+    ),
+    "VLLM_BUILD_FMHA_SM100": lambda: bool(
+        int(os.environ.get("VLLM_BUILD_FMHA_SM100", "1"))
+    ),
+    "VLLM_BUILD_TML_FA4": lambda: bool(
+        int(os.environ.get("VLLM_BUILD_TML_FA4", "1"))
+    ),
     # CMake build type
     # If not set, defaults to "Debug" or "RelWithDebInfo"
     # Available options: "Debug", "Release", "RelWithDebInfo"

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -967,11 +967,27 @@ def safetensors_weights_iterator(
             yield from unflattened_state_dict.items()
         else:
             with safe_open(st_file, framework="pt") as f:
+                param = None
                 for name in f.keys():  # noqa: SIM118
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     param = f.get_tensor(name)
                     yield name, param
+                if _synchronize_safetensors_mmap_before_close():
+                    # Weight copies are asynchronous. Keep the mmap alive until
+                    # the final copy from this shard has completed.
+                    param = None
+
+
+def _synchronize_safetensors_mmap_before_close() -> bool:
+    if (
+        os.name == "nt"
+        and current_platform.is_cuda()
+        and current_platform.is_integrated_gpu(torch.cuda.current_device())
+    ):
+        torch.cuda.synchronize()
+        return True
+    return False
 
 
 def multi_thread_safetensors_weights_iterator(

--- a/vllm/triton_utils/__init__.py
+++ b/vllm/triton_utils/__init__.py
@@ -12,9 +12,13 @@ if TYPE_CHECKING or HAS_TRITON:
     import triton
     import triton.language as tl
     import triton.language.extra.libdevice as tldevice
-    from triton.experimental import gluon
-    from triton.experimental.gluon import language as gl
     from triton.language.core import _aggregate as aggregate  # noqa: E501
+    try:
+        from triton.experimental import gluon
+        from triton.experimental.gluon import language as gl
+    except ImportError:
+        gluon = TritonLanguagePlaceholder()
+        gl = TritonLanguagePlaceholder()
 else:
     triton = TritonPlaceholder()
     tl = TritonLanguagePlaceholder()

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -352,8 +352,14 @@ def find_loaded_library(lib_name: str) -> str | None:
                 cuda_major_version += "0"
             if cuda_path:
                 dll_bin_path = os.path.join(cuda_path, "bin")
-                if os.path.exists(os.path.join(cuda_path, "bin", "x64")):
-                    dll_bin_path = os.path.join(cuda_path, "bin", "x64")
+                cuda_bin_arch = (
+                    "arm64"
+                    if platform.machine().lower() in ("arm64", "aarch64")
+                    else "x64"
+                )
+                arch_bin_path = os.path.join(cuda_path, "bin", cuda_bin_arch)
+                if os.path.exists(arch_bin_path):
+                    dll_bin_path = arch_bin_path
                 cudart_path = os.path.abspath(
                     os.path.join(dll_bin_path, f"cudart64_{cuda_major_version}.dll"))
             else:

--- a/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -4,6 +4,8 @@
 # ruff: noqa: E501
 
 
+import importlib.util
+
 import torch
 
 # isort: off
@@ -72,16 +74,20 @@ def _is_fa3_supported() -> tuple[bool, str | None]:
 def _is_fa4_supported() -> tuple[bool, str | None]:
     if not FA4_AVAILABLE:
         return False, f"FA4 is unavailable due to: {FA4_UNAVAILABLE_REASON}"
+    if importlib.util.find_spec("cutlass") is None:
+        return False, "FA4 requires the nvidia-cutlass-dsl runtime"
     from vllm.platforms import current_platform
 
     if not (
         current_platform.is_device_capability_family(90)
         or current_platform.is_device_capability_family(100)
         or current_platform.is_device_capability_family(110)
+        or current_platform.is_device_capability_family(120)
     ):
         return (
             False,
-            "FA4 is only supported on devices with compute capability 9.x, 10.x, or 11.x",
+            "FA4 is only supported on devices with compute capability "
+            "9.x, 10.x, 11.x, or 12.x",
         )
     return True, None
 


### PR DESCRIPTION
## Purpose

Contribute the validated native Windows ARM64 CUDA 13.4 enablement as a reviewable stack. GitHub native stacks require every branch to live in one repository; because `khmyznikov` does not have push access to `SystemPanic/vllm-windows`, the six-layer native stack lives in the contributor fork and this draft is the cross-fork umbrella.

## Review stack

1. khmyznikov/vllm-windows#1 - build and packaging foundation
2. khmyznikov/vllm-windows#2 - Rust Windows process/listener support
3. khmyznikov/vllm-windows#3 - SM120 CUTLASS indirect launch
4. khmyznikov/vllm-windows#4 - native SM120 FA2 SASS
5. khmyznikov/vllm-windows#5 - FA4 runtime/SM12x gating
6. khmyznikov/vllm-windows#6 - Windows UMA safetensors lifetime

Each stacked PR shows only its layer. This umbrella shows the complete end-to-end diff against `vllm-for-windows`.

## Scope

Generated Windows ARM64 documentation is intentionally omitted. The local NVML capability memoization and missing-FlashInfer sampler fallback are also omitted because active upstream vLLM PRs #50393 and #48956 cover those areas.

## Validation

- Rust workspace compiles on native Windows ARM64; rustfmt passes.
- Focused FA4 tests: 6 passed; Ruff passes.
- Focused UMA loader test: 1 passed; Ruff passes.
- CUTLASS source passes clang-format and the native CUDA build compiles the changed SM120 translation unit.
- Full wheel build and final PE/SASS inspection are running from `C:\Dev\vllm-windows-stack`; results will be added before marking ready.

All commits carry DCO sign-off. AI assistance was used; every changed line and validation result was reviewed by the contributor.